### PR TITLE
Initialize Next.js app skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # client-pilot
-Branded onboarding and task dashboards for service-based businesses
+
+Branded onboarding and task dashboards for service-based businesses.
+
+## Development
+
+1. Copy `.env.example` to `.env` and fill in your Supabase project credentials.
+2. Install dependencies (`npm install`).
+3. Run the development server with `npm run dev`.
+
+The app includes minimal pages for registration, login, a protected dashboard, and a client portal at `/portal/[slug]`.

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabaseClient';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const supabase = createClient();
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (!error) {
+      router.push('/dashboard');
+    } else {
+      alert(error.message);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleLogin} className="w-80 space-y-4">
+        <h1 className="text-2xl font-bold">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full rounded border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full rounded border p-2"
+          required
+        />
+        <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabaseClient';
+
+export default function Register() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const supabase = createClient();
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+    if (!error) {
+      router.push('/dashboard');
+    } else {
+      alert(error.message);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <form onSubmit={handleRegister} className="w-80 space-y-4">
+        <h1 className="text-2xl font-bold">Register</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full rounded border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full rounded border p-2"
+          required
+        />
+        <button type="submit" className="w-full rounded bg-blue-600 p-2 text-white">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabaseClient';
+
+export default function Dashboard() {
+  const router = useRouter();
+  const supabase = createClient();
+  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<any>(null);
+
+  useEffect(() => {
+    const getSession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        router.push('/auth/login');
+      } else {
+        setUser(session.user);
+      }
+      setLoading(false);
+    };
+    getSession();
+  }, [router, supabase]);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    router.push('/');
+  };
+
+  if (loading) return <p>Loading...</p>;
+
+  return (
+    <div className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Dashboard</h1>
+      <p className="mb-2">Logged in as {user?.email}</p>
+      <button
+        onClick={handleLogout}
+        className="rounded bg-red-500 p-2 text-white"
+      >
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Client Pilot',
+  description: 'Task dashboard for clients',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-4xl font-bold">Welcome to Client Pilot</h1>
+    </main>
+  );
+}

--- a/app/portal/[slug]/page.tsx
+++ b/app/portal/[slug]/page.tsx
@@ -1,0 +1,12 @@
+interface PortalProps {
+  params: { slug: string };
+}
+
+export default function Portal({ params }: PortalProps) {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold">Portal: {params.slug}</h1>
+      <p className="mt-4">Here clients can view tasks, fill forms, and upload files.</p>
+    </div>
+  );
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from '@supabase/ssr';
+
+export const createClient = () => {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "client-pilot",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "supabase-js": "2.39.7"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.32",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "@types/react", "@types/node"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup package.json with Next.js, Tailwind and Supabase deps
- configure TypeScript, Tailwind and Next.js
- add Supabase client helper
- add auth pages (register/login)
- add dashboard and portal routes
- provide example environment variables and docs

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6852d49538a48327815d8df0a5b7980c