### PR TITLE
Fix README merge conflict and add usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# client-pilot
+# ClientPilot
 
-Branded onboarding and task dashboards for service-based businesses.
+ClientPilot is a SaaS app for client onboarding and task tracking. It provides branded onboarding and task dashboards for service-based businesses.
 
-## Development
+The app includes minimal pages for registration, login, a protected dashboard with a sidebar and client list, and a client portal at `/portal/[slug]`.
+
+## Setup
 
 1. Copy `.env.example` to `.env` and fill in your Supabase project credentials.
-2. Install dependencies (`npm install`).
-3. Run the development server with `npm run dev`.
+2. Install dependencies with `npm install`.
+3. Start the development server using `npm run dev`.
 
-<<<<<<< HEAD
-The app includes minimal pages for registration, login, a protected dashboard, and a client portal at `/portal/[slug]`.
-=======
-The app includes minimal pages for registration, login, a protected dashboard with a sidebar and client list, and a client portal at `/portal/[slug]`.
->>>>>>> origin/9uq2kt-codex/create-next.js-app-with-typescript-and-tailwind-css
+## Usage
+
+Visit `http://localhost:3000` in your browser to begin onboarding clients and managing tasks.


### PR DESCRIPTION
## Summary
- remove merge conflict markers from README
- describe ClientPilot as a SaaS app for onboarding and task tracking
- add setup steps and usage section

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685945714b1c83279a6488697f52662d